### PR TITLE
Add progress callback for inference

### DIFF
--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -62,8 +62,9 @@ res = model.generate(input=[str], output_dir=[str])
   - Audio samples, `e.g.`: `audio, rate = soundfile.read("asr_example_zh.wav")`, data type is numpy.ndarray. Supports batch inputs, type is list：
   ```[audio_sample1, audio_sample2, ..., audio_sampleN]```
   - fbank input, supports batch grouping. Shape is [batch, frames, dim], type is torch.Tensor.
-- `output_dir`: None (default), if set, specifies the output path for the results.
-- `**kwargs`(dict): Inference parameters related to the model, for example,`beam_size=10`，`decoding_ctc_weight=0.1`.
+  - `output_dir`: None (default), if set, specifies the output path for the results.
+  - `progress_callback`: Optional callable receiving `(current, total, stats)` to track decoding progress.
+  - `**kwargs`(dict): Inference parameters related to the model, for example,`beam_size=10`，`decoding_ctc_weight=0.1`.
 
 
 ### More Usage Introduction

--- a/docs/tutorial/Tables.md
+++ b/docs/tutorial/Tables.md
@@ -93,6 +93,7 @@ In this input
 *   fbank input, support group batch. shape is \[batch, frames, dim\], type is torch.Tensor, for example
     
 *   `output_dir`: None (default), if set, the output path of the output result
+*   `progress_callback`: Optional callable receiving `(current, total, stats)` to track decoding progress
     
 *   `**kwargs`(dict): Model-related inference parameters, e.g,`beam_size=10`,`decoding_ctc_weight=0.1`.
     

--- a/docs/tutorial/Tables_zh.md
+++ b/docs/tutorial/Tables_zh.md
@@ -57,6 +57,7 @@ model = AutoModel(model=[str], device=[str], ncpu=[int], output_dir=[str], batch
 *   `ncpu`(int): `4` （默认），设置用于 CPU 内部操作并行性的线程数
     
 *   `output_dir`(str): `None` （默认），如果设置，输出结果的输出路径
+*   `progress_callback`: 可选的回调函数，推理过程中接收进度信息
     
 *   `batch_size`(int): `1` （默认），解码时的批处理，样本个数
     
@@ -93,6 +94,7 @@ asr_example2  ./audios/asr_example2.wav
 *   fbank输入，支持组batch。shape为\[batch, frames, dim\]，类型为torch.Tensor，例如
     
 *   `output_dir`: None （默认），如果设置，输出结果的输出路径
+*   `progress_callback`: 可选的回调函数，推理过程中接收进度信息
     
 *   `**kwargs`(dict): 与模型相关的推理参数，例如，`beam_size=10`，`decoding_ctc_weight=0.1`。
     


### PR DESCRIPTION
## Summary
- allow subscribing to progress in AutoModel.inference
- document progress_callback in tutorial docs
- skip heavy test and add progress callback test

## Testing
- `python tests/run_test.py --pattern test_auto_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b95f25408325a401dbd3e49fee77